### PR TITLE
Style update for selecting lot template in mobile mode

### DIFF
--- a/src/components/side_bar/content/cards/card_editor/lot_editor.js
+++ b/src/components/side_bar/content/cards/card_editor/lot_editor.js
@@ -7,6 +7,9 @@ import {getCardsCount} from "../../../../../api/cards_api";
 import PropTypes from "prop-types";
 import {Formik, setNestedObjectValues} from "formik";
 import {useDispatch, useSelector} from "react-redux";
+import {
+	isMobile
+} from "react-device-detect";
 
 // external components
 import FadeLoader from "react-spinners/FadeLoader"
@@ -847,6 +850,19 @@ const FormComponent = (props) => {
 
 				<styled.Footer>
 					{/* render buttons for appropriate content */}
+					{(isMobile && showTemplateSelector) ?
+					<styled.ButtonContainer>
+						<Button
+							type={"button"}
+							style={{...buttonStyle, }}
+							onClick={() => setShowTemplateSelector(false)}
+							schema={"lots"}
+							// secondary
+						>
+							Back to Editor
+						</Button>
+					</styled.ButtonContainer>
+					:
 					<styled.ButtonContainer>
 						{
 							{
@@ -1025,6 +1041,7 @@ const FormComponent = (props) => {
 						}
 
 					</styled.ButtonContainer>
+					}
 
 
 					{footerContent()}

--- a/src/components/side_bar/content/cards/card_editor/lot_sidebars/template_selector_sidebar/template_selector_sidebar.js
+++ b/src/components/side_bar/content/cards/card_editor/lot_sidebars/template_selector_sidebar/template_selector_sidebar.js
@@ -82,7 +82,10 @@ const TemplateSelectorSidebar = (props) => {
                 }
                 <style.LotTemplateButton
                     isSelected={selectedLotTemplatesId === BASIC_LOT_TEMPLATE_ID}
-                    onClick={() => dispatchSetSelectedLotTemplate(BASIC_LOT_TEMPLATE_ID)}
+                    onClick={() => {
+                        dispatchSetSelectedLotTemplate(BASIC_LOT_TEMPLATE_ID)
+                        isMobile && onCloseClick()
+                    }}
                 >
                     <style.TemplateIcon
                         isSelected={selectedLotTemplatesId === BASIC_LOT_TEMPLATE_ID}
@@ -109,6 +112,7 @@ const TemplateSelectorSidebar = (props) => {
                             isSelected={isSelected}
                             onClick={() => {
                                 dispatchSetSelectedLotTemplate(currTemplateId)
+                                isMobile && onCloseClick()
                             }}
                         >
                             <style.TemplateIcon


### PR DESCRIPTION
Sidebar takes entire width of screen
Clicking template closes side bar
Also has button at bottom of sidebar to close it