### PR TITLE
fix lot existing name warning

### DIFF
--- a/src/components/side_bar/content/cards/card_editor/lot_editor.js
+++ b/src/components/side_bar/content/cards/card_editor/lot_editor.js
@@ -113,8 +113,6 @@ const FormComponent = (props) => {
 
 	const formMode = cardId ? FORM_MODES.UPDATE : FORM_MODES.CREATE
 
-	useWarn(uniqueNameSchema, formikProps)
-
 	const themeContext = useContext(ThemeContext);
 
 	// actions


### PR DESCRIPTION
Existing name warning was disappearing after a few seconds. This should fix it