### PR TITLE
HOTFIX: Fix new stations not showing up in list view

### DIFF
--- a/src/api/stations_api.js
+++ b/src/api/stations_api.js
@@ -66,8 +66,6 @@ export async function deleteStation(ID) {
         const data = response.data;
         const dataJson = JSON.parse(data)
 
-        console.log(dataJson)
-
         return dataJson
 
     } catch (error) {

--- a/src/components/list_view/list_view.js
+++ b/src/components/list_view/list_view.js
@@ -202,6 +202,12 @@ const ListView = (props) => {
                           color={"black"}
                           onClick={() => {
                              setShowSettings(!showSettings)
+                              if(showSettings) {
+                                  history.push(`/`)
+                              }
+                              else {
+                                  history.push(`/settings`)
+                              }
                           }}
                           active={showSettings}
                           containerStyle={{

--- a/src/components/side_bar/content/settings/settings.js
+++ b/src/components/side_bar/content/settings/settings.js
@@ -30,8 +30,11 @@ import { setCurrentMap } from '../../../../redux/actions/map_actions'
 // Import Utils
 import { isEquivalent } from '../../../../methods/utils/utils'
 import config from '../../../../settings/config'
+import {useHistory} from "react-router-dom";
 
 const Settings = () => {
+
+    const history = useHistory()
 
     const dispatch = useDispatch()
     const dispatchPostSettings = (settings) => dispatch(postSettings(settings))
@@ -176,6 +179,9 @@ const Settings = () => {
         await dispatchGetStatus()
         await dispatchGetLocalSettings()
 
+        if(!localSettingsState.mapViewEnabled) {
+            history.push(`/`)
+        }
 
     }
 

--- a/src/containers/api_container/api_container.js
+++ b/src/containers/api_container/api_container.js
@@ -251,6 +251,10 @@ const ApiContainer = (props) => {
                 setPageDataInterval(setInterval(() => loadDashboardsData(), 3000))
                 break;
 
+            case 'locations':
+                setPageDataInterval(setInterval(() => loadLocationsData(), 5000))
+                break
+
             case 'tasks':
                 setPageDataInterval(setInterval(() => loadTasksData(), 10000))
                 break;
@@ -288,6 +292,9 @@ const ApiContainer = (props) => {
                 break;
 
             default:
+                if(!mapViewEnabled) {
+                    setPageDataInterval(setInterval(() => loadListViewData(), 5000))
+                }
                 break;
         }
 
@@ -390,6 +397,16 @@ const ApiContainer = (props) => {
         const tasks = await onGetTasks()
         const processes = await onGetProcesses()
         const objects = await onGetObjects()
+    }
+
+    const loadLocationsData = () => {
+        onGetDashboards()
+        onGetStations()
+    }
+
+    const loadListViewData = () => {
+        onGetStations()
+        onGetDashboards()
     }
 
     /*

--- a/src/redux/reducers/stations_reducer.js
+++ b/src/redux/reducers/stations_reducer.js
@@ -28,6 +28,7 @@ import {
 // Import Utils
 import { deepCopy } from '../../methods/utils/utils';
 import { compareExistingVsIncomingLocations } from '../../methods/utils/locations_utils'
+import {isEmpty} from "../../methods/utils/object_utils";
 
 const defaultState = {
     stations: {},
@@ -134,12 +135,24 @@ export default function stationsReducer(state = defaultState, action) {
             });
 
         case GET_STATIONS_SUCCESS:
-            const parsedStations = compareExistingVsIncomingLocations(deepCopy(action.payload), deepCopy(state.stations), state.d3)
-            return {
-                ...state,
-                stations: parsedStations,
-                pending: false
+            if(isEmpty(state.d3)) {
+                return {
+                    ...state,
+                    stations: {...action.payload},
+                    pending: false
+                }
             }
+
+            else {
+                const parsedStations = compareExistingVsIncomingLocations(deepCopy(action.payload), deepCopy(state.stations), state.d3)
+
+                return {
+                    ...state,
+                    stations: parsedStations,
+                    pending: false
+                }
+            }
+
 
         case GET_STATIONS_FAILURE:
             return Object.assign({}, state, {


### PR DESCRIPTION
When in the list view, if a station was added from another device / browser, the station wouldn't show up in the list view in some cases.

This was caused by:
1. there not being a data interval for "/"
2. a function in the stations reducer that doesn't work if d3 hasn't been dispatched, which it won't be if the map view never renders