### PR TITLE
HOTFIX: adding multiple buttons to same dashboard via process

### DIFF
--- a/src/components/side_bar/content/processes/process_field/process_field.js
+++ b/src/components/side_bar/content/processes/process_field/process_field.js
@@ -1,19 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 
-// external functions
-import uuid from 'uuid'
-import { useSelector, useDispatch } from 'react-redux'
-
-// internal components
-import Textbox from '../../../../basic/textbox/textbox.js'
-import Button from '../../../../basic/button/button'
-import TaskField from '../../tasks/task_field/route_field'
-import ContentHeader from '../../content_header/content_header'
-import ConfirmDeleteModal from '../../../../basic/modals/confirm_delete_modal/confirm_delete_modal'
-import TextField from "../../../../basic/form/text_field/text_field";
-import ListItemField from "../../../../basic/form/list_item_field/list_item_field";
-
-// Import actions
+// actions
 import {
     deleteRouteClean,
     postRouteClean,
@@ -25,29 +12,40 @@ import { setSelectedProcess, setFixingProcess } from '../../../../../redux/actio
 import { handlePostTaskQueue, postTaskQueue } from '../../../../../redux/actions/task_queue_actions'
 import { pageDataChanged } from "../../../../../redux/actions/sidebar_actions"
 
+// constants
+import { DEVICE_CONSTANTS } from "../../../../../constants/device_constants";
+import { ADD_TASK_ALERT_TYPE } from "../../../../../constants/dashboard_contants";
 
-// Import Utils
+// functions external
+import uuid from 'uuid'
+import { useSelector, useDispatch } from 'react-redux'
+
+// components internal
+import Textbox from '../../../../basic/textbox/textbox.js'
+import Button from '../../../../basic/button/button'
+import TaskField from '../../tasks/task_field/route_field'
+import ContentHeader from '../../content_header/content_header'
+import ConfirmDeleteModal from '../../../../basic/modals/confirm_delete_modal/confirm_delete_modal'
+import TextField from "../../../../basic/form/text_field/text_field";
+import ListItemField from "../../../../basic/form/list_item_field/list_item_field";
+import TaskAddedAlert from "../../../../widgets/widget_pages/dashboards_page/dashboard_screen/task_added_alert/task_added_alert";
+import AddRouteButtonPath from '../../../../../graphics/svg/add_route_button_path'
+
+// utils
 import {
     generateDefaultRoute, getLoadStationDashboard,
     getRouteProcesses,
-    isHumanTask,
-    isMiRTask
 } from "../../../../../methods/utils/route_utils";
-import { isBrokenProcess, willRouteAdditionFixProcess, willRouteDeleteBreakProcess } from "../../../../../methods/utils/processes_utils";
+import { isBrokenProcess, willRouteDeleteBreakProcess } from "../../../../../methods/utils/processes_utils";
 import { isEmpty, isObject } from "../../../../../methods/utils/object_utils";
 import useChange from "../../../../basic/form/useChange";
+import { throttle } from "../../../../../methods/utils/function_utils";
+import { getSidebarDeviceType, isRouteInQueue } from "../../../../../methods/utils/task_queue_utils";
+import { isDeviceConnected } from "../../../../../methods/utils/device_utils";
 
 // styles
 import * as styled from './process_field.style'
 import theme from '../../../../../theme'
-import { DEVICE_CONSTANTS } from "../../../../../constants/device_constants";
-import { throttle } from "../../../../../methods/utils/function_utils";
-import { ADD_TASK_ALERT_TYPE } from "../../../../../constants/dashboard_contants";
-import TaskAddedAlert
-    from "../../../../widgets/widget_pages/dashboards_page/dashboard_screen/task_added_alert/task_added_alert";
-import { getSidebarDeviceType, isRouteInQueue } from "../../../../../methods/utils/task_queue_utils";
-import { isDeviceConnected } from "../../../../../methods/utils/device_utils";
-import AddRouteButtonPath from '../../../../../graphics/svg/add_route_button_path'
 
 export const ProcessField = (props) => {
     const {

--- a/src/components/side_bar/content/processes/process_form/process_form.js
+++ b/src/components/side_bar/content/processes/process_form/process_form.js
@@ -1,26 +1,30 @@
-import {useDispatch, useSelector} from "react-redux";
-import {Formik} from "formik";
-import {processSchema} from "../../../../../methods/utils/form_schemas";
 import React, {useEffect} from "react";
-import {ProcessField} from "../process_field/process_field";
-import uuid from 'uuid'
+
+// actions
 import {
 	deleteRouteClean,
-	deleteTask,
-	putRouteClean,
-	putTask, saveFormRoute,
+	saveFormRoute,
 	setSelectedTask
 } from "../../../../../redux/actions/tasks_actions";
 import {
-	deleteProcess, deleteProcessClean,
+	deleteProcessClean,
 	postProcesses,
 	putProcesses,
 	setSelectedProcess
 } from "../../../../../redux/actions/processes_actions";
-import * as taskActions from "../../../../../redux/actions/tasks_actions";
-import {isObject} from "../../../../../methods/utils/object_utils";
-import {isArray} from "../../../../../methods/utils/array_utils";
 import { pageDataChanged } from "../../../../../redux/actions/sidebar_actions"
+
+// functions external
+import {useDispatch, useSelector} from "react-redux";
+import {Formik} from "formik";
+import uuid from 'uuid'
+
+// utils
+import {processSchema} from "../../../../../methods/utils/form_schemas";
+import {isObject} from "../../../../../methods/utils/object_utils";
+
+// components internal
+import {ProcessField} from "../process_field/process_field";
 
 const ProcessForm = (props) => {
 
@@ -30,14 +34,10 @@ const ProcessForm = (props) => {
 
 	const dispatchSetSelectedTask = (task) => dispatch(setSelectedTask(task))
 
-
 	const dispatch = useDispatch()
 	const dispatchPostProcess = async (process) => await dispatch(postProcesses(process))
 
 	const dispatchPutProcess = async (process) => await dispatch(putProcesses(process))
-
-	const dispatchPostRouteClean = async (route) => await dispatch(taskActions.postRouteClean(route))
-	const dispatchPutRouteClean = (task, ID) => dispatch(putRouteClean(task, ID))
 
 	const dispatchSetSelectedProcess = (process) => dispatch(setSelectedProcess(process))
 	const dispatchDeleteProcessClean = async (ID) => await dispatch(deleteProcessClean(ID))

--- a/src/redux/actions/dashboards_actions.js
+++ b/src/redux/actions/dashboards_actions.js
@@ -273,7 +273,7 @@ export const addRouteToDashboards = (route) => {
 
             // only add button if it isn't already in the dashboard
             if(buttonIndex === -1) {
-                dispatch(putDashboard({
+                await dispatch(putDashboard({
                     ...dashboard,
                     buttons: [...dashboard.buttons, newDashboardButton]
                 }, dashboard._id.$oid))

--- a/src/redux/actions/tasks_actions.js
+++ b/src/redux/actions/tasks_actions.js
@@ -274,12 +274,12 @@ export const saveFormRoute = (formRoute) => {
 
         // create new route
         if(isNew) {
-            dispatch(postRouteClean(payload))
+            await dispatch(postRouteClean(payload))
         }
 
         // update existing route
         else {
-            dispatch(putRouteClean(payload, payload._id))
+            await dispatch(putRouteClean(payload, payload._id))
         }
     }
 }


### PR DESCRIPTION
When creating a process, if two (or more) routes are made (at the same time) that should add buttons to the same dashboard, only one would show up. This was because of missing awaits in actions used to add the buttons, so the last one would overwrite the previous.

This PR adds the awaits to fix this bug