### PR TITLE
Fix race when adding multiple routes that add button to same dashboard

### DIFF
--- a/src/redux/actions/dashboards_actions.js
+++ b/src/redux/actions/dashboards_actions.js
@@ -254,15 +254,12 @@ export const addRouteToDashboards = (route) => {
                 buttons: [newDashboardButton],
                 station: station._id
             }
-            const postDashboardPromise = dispatch(postDashboard(defaultDashboard))
-            postDashboardPromise.then(async postedDashboard => {
-                alert('Added dashboard to location. There already should be a dashboard tied to this location, so this is an temp fix')
-                await dispatch(stationActions.putStation({
-                    ...station,
-                    dashboards: [postedDashboard._id.$oid]
-                }, station._id))
-
-            })
+            const postedDashboard = await dispatch(postDashboard(defaultDashboard))
+            alert('Added dashboard to location. There already should be a dashboard tied to this location, so this is an temp fix')
+            await dispatch(stationActions.putStation({
+                ...station,
+                dashboards: [postedDashboard._id.$oid]
+            }, station._id))
         }
 
         else {
@@ -273,7 +270,7 @@ export const addRouteToDashboards = (route) => {
 
             // only add button if it isn't already in the dashboard
             if(buttonIndex === -1) {
-                dispatch(putDashboard({
+                await dispatch(putDashboard({
                     ...dashboard,
                     buttons: [...dashboard.buttons, newDashboardButton]
                 }, dashboard._id.$oid))

--- a/src/redux/actions/tasks_actions.js
+++ b/src/redux/actions/tasks_actions.js
@@ -274,12 +274,12 @@ export const saveFormRoute = (formRoute) => {
 
         // create new route
         if(isNew) {
-            dispatch(postRouteClean(payload))
+            await dispatch(postRouteClean(payload))
         }
 
         // update existing route
         else {
-            dispatch(putRouteClean(payload, payload._id))
+            await dispatch(putRouteClean(payload, payload._id))
         }
     }
 }


### PR DESCRIPTION
When creating a process, if two (or more) routes are made (at the same time) that should add buttons to the same dashboard, only one would show up. This was because of missing awaits in actions used to add the buttons, so the last one would overwrite the previous.

This PR adds the awaits to fix this bug