### PR TITLE
Fix issue with confirm unload fraction task no longer behaving as confirm unload when removed from process

### DIFF
--- a/src/components/hil_modals/hil_modals.js
+++ b/src/components/hil_modals/hil_modals.js
@@ -427,7 +427,7 @@ const HILModals = (props) => {
         // If its a load, then add a quantity to the response
         if (hilLoadUnload === 'load') {
             // If track quantity then add quantity, or if noLotSelected then use quantity
-            if (!!selectedTask.track_quantity || !!noLotsSelected) {
+            if (!!selectedTask.track_quantity || !!noLotsSelected || trackQuantity) {
                 newItem.quantity = quantity
             }
 


### PR DESCRIPTION
Not 100% sure what the intended design is here, but it looks like fraction tasks are treated as quantity if no longer in a process. If this is the intended design, this fixes the bug