### PR TITLE
Prevent editing lot name in lot editor if not in main lot editor screen: RM-19

### DIFF
--- a/src/components/basic/textbox/textbox.style.js
+++ b/src/components/basic/textbox/textbox.style.js
@@ -34,7 +34,7 @@ export const TextboxInput = styled.input`
     flex-grow: 1;
     color: ${props => props.theme.bg.octonary};
 
-    box-shadow: 0 0.1rem 0.2rem 0rem rgba(0,0,0,0.1) !important;
+    box-shadow: 0 0.1rem 0.2rem 0rem rgba(0,0,0,0.1);
     border-bottom: 2px solid ${props => props.theme.bg.secondary};
 
     &:focus {

--- a/src/components/side_bar/content/cards/card_editor/lot_editor.js
+++ b/src/components/side_bar/content/cards/card_editor/lot_editor.js
@@ -816,19 +816,31 @@ const FormComponent = (props) => {
 
 							<styled.RowContainer >
 								<styled.NameContainer style={{flex: 0}}>
-									<styled.LotName>Lot Number</styled.LotName>
+									<styled.FieldLabel>Lot Number</styled.FieldLabel>
 									<styled.LotNumber>{formatLotNumber(lotNumber)}</styled.LotNumber>
 								</styled.NameContainer>
 
 								<styled.NameContainer>
-									<styled.LotName>{getDisplayName(lotTemplate, "name", DEFAULT_NAME_DISPLAY_NAME)}</styled.LotName>
-									<TextField
-										name={"name"}
-										type={"text"}
-										placeholder={"Enter name..."}
-										InputComponent={Textbox}
-										schema={"lots"}
-									/>
+									<styled.FieldLabel>{getDisplayName(lotTemplate, "name", DEFAULT_NAME_DISPLAY_NAME)}</styled.FieldLabel>
+										<TextField
+											disabled={content !== null}
+											inputStyle={content !== null ? {
+												background: "transparent",
+												border: "none",
+												boxShadow: "none",
+
+											} : {}}
+											style={content !== null ? {
+												background: "transparent",
+												border: "none",
+												boxShadow: "none",
+											} : {}}
+											name={"name"}
+											type={"text"}
+											placeholder={"Enter name..."}
+											InputComponent={Textbox}
+											schema={"lots"}
+										/>
 								</styled.NameContainer>
 							</styled.RowContainer>
 						</styled.FieldsHeader>

--- a/src/components/side_bar/content/cards/card_editor/lot_editor.style.js
+++ b/src/components/side_bar/content/cards/card_editor/lot_editor.style.js
@@ -91,7 +91,7 @@ export const InfoText = styled.span`
   font-size: ${props => props.theme.fontSize.sz3};
   // font-weight: ${props => props.theme.fontWeight.bold};
   font-family: ${props => props.theme.font.primary};
-  color: ${props => props.highlight ? props.theme.schema[props.schema].solid : "white"};
+  color: ${props => props.highlight ? props.theme.schema[props.schema].solid : props.textColor};
 `
 
 export const SectionContainer = styled.div`
@@ -468,7 +468,7 @@ export const ContentValue = styled.span`
 //   font-weight: ${props => props.theme.fontWeight.no};
 // `
 
-export const LotName = styled.span`
+export const FieldLabel = styled.span`
 	font-size: ${props => props.theme.fontSize.sz3};
 	font-weight: ${props => props.theme.fontWeight.bold};
 	font-family: ${props => props.theme.font.primary};
@@ -477,8 +477,8 @@ export const LotName = styled.span`
 	margin-bottom: .5rem;
 `
 
-export const LotNumber = styled.div`
-  /* background-color: ${props => props.theme.bg.secondary}; */
+const fieldValueCss = css`
+ /* background-color: ${props => props.theme.bg.secondary}; */
   border: none;
   font-size: ${props => props.theme.fontSize.sz4};
   font-family: ${props => props.theme.font.primary};
@@ -494,8 +494,17 @@ export const LotNumber = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  
-  padding: 0 2rem;
+`
+
+export const LotName = styled.span`
+  ${fieldValueCss};
+  padding: 0 .5rem;
+`
+
+export const LotNumber = styled.div`
+	${fieldValueCss};
+	
+	padding: 0 2rem;
 `
 
 export const TemplateButton = styled.button`


### PR DESCRIPTION
Before could edit lot name when moving lot or viewing lot history.
Now can only edit name if in main editor screen.