### PR TITLE
HOTFIX: update logic for disabling stations / positions on map when editing process

### DIFF
--- a/src/components/map/locations/position/position.js
+++ b/src/components/map/locations/position/position.js
@@ -23,11 +23,13 @@ import LocationSvg from '../location_svg/location_svg'
 import DragEntityProto from '../drag_entity_proto'
 import { getPreviousRoute } from "../../../../methods/utils/processes_utils";
 import {
+    getLoadPositionId,
     getLoadStationId, getRouteEnd, getRouteIndexInRoutes, getRouteStart,
     isPositionAtLoadStation, isPositionAtUnloadStation,
     isPositionInRoutes,
-    isStationInRoutes, isStationLoadStation
+    isStationInRoutes, isStationLoadStation, isStationUnloadStation
 } from "../../../../methods/utils/route_utils";
+import {immutableDelete} from "../../../../methods/utils/array_utils";
 
 function Position(props) {
 
@@ -147,13 +149,21 @@ function Position(props) {
                         }
 
                         else if (routeIndex === 0) {
-                            if (isPositionInRoutes(selectedProcess.routes, positionId) && !isPositionAtLoadStation(selectedTask, positionId)) disabled = true
+                            if (isPositionInRoutes(immutableDelete(selectedProcess.routes, 0), positionId)) disabled = true
                         }
 
                         else {
                             // must start at position at unload station of previous route
                             const previousRoute = getPreviousRoute(selectedProcess.routes, selectedTask._id)
-                            disabled = !isPositionAtUnloadStation(previousRoute, positionId)
+                            const previousRouteEnd = getRouteEnd(previousRoute)
+                            if(!isPositionAtUnloadStation(previousRoute, positionId) && previousRouteEnd) disabled = true
+
+
+
+                            const loadPositionId = getLoadPositionId(selectedTask)
+                            const loadStationId = getLoadStationId(selectedTask)
+
+                            if (isPositionInRoutes(selectedProcess.routes, positionId) && (previousRouteEnd !== position.parent) && positionId !== loadPositionId && loadStationId !== position.parent) disabled = true
                         }
                     }
 

--- a/src/components/map/locations/station/station.js
+++ b/src/components/map/locations/station/station.js
@@ -25,6 +25,7 @@ import LocationSvg from '../location_svg/location_svg'
 import DragEntityProto from '../drag_entity_proto'
 import { getPreviousRoute } from "../../../../methods/utils/processes_utils";
 import {
+    getHasStartAndEnd, getLoadStationId,
     getRouteEnd,
     getRouteIndexInRoutes, getRouteStart,
     getUnloadStationId,
@@ -32,6 +33,7 @@ import {
     isStationInRoutes,
     isStationLoadStation, isStationUnloadStation
 } from "../../../../methods/utils/route_utils";
+import {immutableDelete} from "../../../../methods/utils/array_utils";
 
 function Station(props) {
     const {
@@ -120,6 +122,7 @@ function Station(props) {
                 insertIndex
             } = temp || {}
 
+
             if (selectedProcess.routes.length > 0) {
                 const routeIndex = getRouteIndexInRoutes(selectedProcess.routes.map((currProcess) => currProcess._id), selectedTask?._id)
 
@@ -134,14 +137,18 @@ function Station(props) {
 
 
                     else if (routeIndex === 0) {
-                        const firstRoute = selectedProcess.routes[0]
-                        if (isStationInRoutes(selectedProcess.routes, station._id)  && selectedProcess.routes.length > 1 && !isStationLoadStation(selectedTask, station._id)) disabled = true
+                        if (isStationInRoutes(immutableDelete(selectedProcess.routes, 0), station._id)) disabled = true
                     }
 
                     else {
                         // must select unload station of previous route
                         const previousRoute = getPreviousRoute(selectedProcess.routes, selectedTask._id)
-                        if (!isStationUnloadStation(previousRoute, station._id)) disabled = true
+                        const previousRouteEnd = getRouteEnd(previousRoute)
+
+                        if (!isStationUnloadStation(previousRoute, station._id) && previousRouteEnd) disabled = true
+
+                        const loadStationId = getLoadStationId(selectedTask)
+                        if (isStationInRoutes(selectedProcess.routes, station._id) && station._id !== loadStationId && previousRouteEnd !== station._id) disabled = true
                     }
                 }
 

--- a/src/components/map/locations/station/station.js
+++ b/src/components/map/locations/station/station.js
@@ -81,144 +81,115 @@ function Station(props) {
     if (!!selectedStation && selectedStation._id === station._id && !selectedTask && !!editingStation) isSelected = true
 
     let disabled = false
-    // Disable if the selected station is not this station
-    if (!!selectedStation && selectedStation._id !== station._id) disabled = true
+    if(!!selectedTask && !!selectedProcess) {
+        // This filters out stations when fixing a process
+        // If the process is broken, then you can only start the task at the route before break's unload location
 
-    // Disable if theres a selected position and the station's children dont contain that position
-    else if (!!selectedPosition && !station.children.includes(selectedPosition._id)) disabled = true
-
-    // Disables while making task (IE no unload station) and not fixing a process
-    else if (!!selectedTask && selectedTask?.load?.station !== null && selectedTask?.unload?.station === null && !fixingProcess) {
-        // Disable making a task to this station if the selected position is the stations children (cant make a route to the same parent/child)
-        if (station.children.includes(selectedTask?.load?.position) && selectedTask?.unload?.station === null) disabled = true
-
-        // Disable station if the selected task load position is a position (cant go from station to position or vice versa)
-        else if (!!positions[selectedTask?.load?.position]) disabled = true
-        // Disable station if its the load station. Cant make a task to itself
-        else if (selectedTask.load.station === station._id) disabled = true
-
-        // Disables when adding a task to the beginning of a process. 
-        // To tell if a task is being added to the beginning of a process is when the task has a temp insert index at 0
-        else if (selectedTask?.temp?.insertIndex === 0 && !!selectedProcess && selectedProcess.routes.length > 0) {
-            // Find the station at the beginning of process
-            const firstStation = selectedProcess.routes[0].load.station
-
-            if (station._id !== firstStation && selectedTask.load.station !== null) disabled = true
-        }
-
-        // Disable making a task to this station if it is already used in the process and its not adding to the beginnig of the process
-        else if (!!selectedProcess) {
-            const processesStations = getProcessStationsWhileEditing(selectedProcess, tasks)
-            if (processesStations.includes(station._id) && selectedTask?.temp?.insertIndex !== 0) disabled = true
-        }
-    }
-
-
-    // This filters out stations when fixing a process
-    // If the process is broken, then you can only start the task at the route before break's unload location
-    else if (!!selectedTask && !!selectedProcess && !!fixingProcess) {
-
-        // setting load
-        if (!routeStart || (routeStart && routeEnd)) {
-
-            // must start at unload station of route before the break
-            const routeBeforeBreak = selectedProcess.routes[selectedProcess.broken - 1]
-            if (!isStationUnloadStation(routeBeforeBreak, station._id)) disabled = true
-        }
-
-        // setting unload
-        else if (!routeEnd) {
-
-            // can't pick same station for load and unload
-            if (isStationLoadStation(selectedTask, station._id)) disabled = true
-
-            // disable stations already in process
-            if (isStationInRoutes(selectedProcess.routes, station._id)) disabled = true
-
-            // always allow picking load station of route after the break, as this would fix the break
-            const routeAfterBreak = selectedProcess.routes[selectedProcess.broken] || {}
-            if (isStationLoadStation(routeAfterBreak, station._id)) disabled = false
-        }
-    }
-
-    // This filters stations when making a process
-    // If the process has routes, and you're adding a new route, you should only be able to add a route starting at the last station
-    // This eliminates process with gaps between stations
-    else if (!!selectedProcess && !!selectedTask) {
-        const {
-            temp
-        } = selectedTask || {}
-        const {
-            insertIndex
-        } = temp || {}
-
-        if (selectedProcess.routes.length > 0) {
-            const routeIndex = getRouteIndexInRoutes(selectedProcess.routes.map((currProcess) => currProcess._id), selectedTask?._id)
-
-            // setting load station
+        if (!!fixingProcess) {
+            // setting load
             if (!routeStart || (routeStart && routeEnd)) {
 
-                // adding to beginning
-                if (insertIndex === 0) {
-                    // disable is station is already in process
-                    if (isStationInRoutes(selectedProcess.routes, station._id)) disabled = true
-                }
-
-
-                else if (routeIndex === 0) {
-                    if (isStationInRoutes(selectedProcess.routes, station._id)) disabled = true
-                    if (isStationLoadStation(selectedTask, station._id)) disabled = false
-                }
-
-                else {
-                    // must select unload station of previous route
-                    const previousRoute = getPreviousRoute(selectedProcess.routes, selectedTask._id)
-                    if (!isStationUnloadStation(previousRoute, station._id)) disabled = true
-                }
+                // must start at unload station of route before the break
+                const routeBeforeBreak = selectedProcess.routes[selectedProcess.broken - 1]
+                if (!isStationUnloadStation(routeBeforeBreak, station._id)) disabled = true
             }
 
+            // setting unload
             else if (!routeEnd) {
+                if (!!positions[selectedTask?.load?.position]) disabled = true
 
-                // adding to beginning of process
-                if (insertIndex === 0) {
+                // can't pick same station for load and unload
+                if (isStationLoadStation(selectedTask, station._id)) disabled = true
 
-                    // disable stations already in process
-                    if (isStationInRoutes(selectedProcess.routes, station._id)) disabled = true
+                // always allow picking load station of route after the break, as this would fix the break
+                const routeAfterBreak = selectedProcess.routes[selectedProcess.broken] || {}
 
-                    // don't allow selecting same station for load and unload
-                    if (isStationLoadStation(selectedTask, station._id)) disabled = true
-
-                    // always allow selecting load station of first route, as we are adding to the beginning of the process
-                    const firstRoute = selectedProcess.routes[0]
-                    if (isStationLoadStation(firstRoute, station._id)) disabled = false
-                }
-
-                else if (routeIndex === 0) {
-                    // disable stations already in process
-                    if (isStationInRoutes(selectedProcess.routes, station._id)) disabled = true
-
-                    const nextRoute = selectedProcess.routes[1]
-                    if (isStationLoadStation(nextRoute, station._id)) disabled = false
-                }
-
-                else {
-                    // disable stations already in process
-                    if (isStationInRoutes(selectedProcess.routes, station._id)) disabled = true
-
-                    const nextRoute = selectedProcess.routes[routeIndex + 1]
-                    if (isStationLoadStation(nextRoute, station._id)) disabled = false
-                }
+                // disable stations already in process
+                if (isStationInRoutes(selectedProcess.routes, station._id) && !isStationLoadStation(routeAfterBreak, station._id)) disabled = true
             }
         }
 
-        // editing first route
+            // This filters stations when making a process
+            // If the process has routes, and you're adding a new route, you should only be able to add a route starting at the last station
+        // This eliminates process with gaps between stations
         else {
-            if ((selectedTask.load.station && selectedTask.unload.station === null)) {
-                // don't allow selecting same station for load and unload
-                if (isStationLoadStation(selectedTask, station._id)) disabled = true
+            const {
+                temp
+            } = selectedTask || {}
+            const {
+                insertIndex
+            } = temp || {}
+
+            if (selectedProcess.routes.length > 0) {
+                const routeIndex = getRouteIndexInRoutes(selectedProcess.routes.map((currProcess) => currProcess._id), selectedTask?._id)
+
+                // setting load station
+                if (!routeStart || (routeStart && routeEnd)) {
+
+                    // adding to beginning
+                    if (insertIndex === 0) {
+                        // disable is station is already in process
+                        if (isStationInRoutes(selectedProcess.routes, station._id)) disabled = true
+                    }
+
+
+                    else if (routeIndex === 0) {
+                        const firstRoute = selectedProcess.routes[0]
+                        if (isStationInRoutes(selectedProcess.routes, station._id)  && selectedProcess.routes.length > 1 && !isStationLoadStation(selectedTask, station._id)) disabled = true
+                    }
+
+                    else {
+                        // must select unload station of previous route
+                        const previousRoute = getPreviousRoute(selectedProcess.routes, selectedTask._id)
+                        if (!isStationUnloadStation(previousRoute, station._id)) disabled = true
+                    }
+                }
+
+                else if (!routeEnd) {
+                    if (!!positions[selectedTask?.load?.position]) disabled = true
+
+                    // adding to beginning of process
+                    if (insertIndex === 0) {
+
+                        // disable stations already in process
+                        const firstRoute = selectedProcess.routes[0]
+                        if (isStationInRoutes(selectedProcess.routes, station._id) && !isStationLoadStation(firstRoute, station._id)) disabled = true
+
+                        // don't allow selecting same station for load and unload
+                        if (isStationLoadStation(selectedTask, station._id)) disabled = true
+                    }
+
+                    else if (routeIndex === 0) {
+                        // disable stations already in process
+                        const nextRoute = selectedProcess.routes[1]
+                        if (isStationInRoutes(selectedProcess.routes, station._id) && !isStationLoadStation(nextRoute, station._id)) disabled = true
+                    }
+
+                    else {
+                        // disable stations already in process
+                        const nextRoute = selectedProcess.routes[routeIndex + 1]
+                        if (isStationInRoutes(selectedProcess.routes, station._id) && (!isStationLoadStation(nextRoute, station._id) || routeIndex === -1)) disabled = true
+                    }
+                }
+            }
+
+            // editing first route
+            else {
+                if ((selectedTask.load.station && selectedTask.unload.station === null)) {
+                    // don't allow selecting same station for load and unload
+                    if (isStationLoadStation(selectedTask, station._id)) disabled = true
+                }
             }
         }
     }
+    else {
+        // Disable if the selected station is not this station
+        if (!!selectedStation && selectedStation._id !== station._id) disabled = true
+
+        // Disable if theres a selected position and the station's children dont contain that position
+        else if (!!selectedPosition && !station.children.includes(selectedPosition._id)) disabled = true
+    }
+
 
     const shouldGlow = false
 

--- a/src/components/map/process_paths/process_paths.js
+++ b/src/components/map/process_paths/process_paths.js
@@ -11,24 +11,54 @@ const ProcessPaths = (props) => {
 
     const selectedProcess = useSelector(state => state.processesReducer.selectedProcess)
     const tasks = useSelector(state => state.tasksReducer.tasks)
+    const editingTask = useSelector(state => state.tasksReducer.editingTask)
+    const selectedTask = useSelector(state => state.tasksReducer.selectedTask)
 
     // Maps through all the associated routes with the process and displays them
     const handleTaskPaths = () => {
-        // return Object.keys(selectedProcess.routes).map((station, ind) => {
-        return selectedProcess.routes.map((route, ind) => {
-            if( isObject(route) ) {
-                return (
-                    <TaskPaths d3={d3} route={route} key={route._id} />
-                )
-            }
-            else {
-                return (
-                    <TaskPaths d3={d3} route={tasks[route]} key={route} />
-                )
-            }
-        })
+        return selectedProcess.routes
+            .filter((route) => {
+                const {
+                    load,
+                    unload,
+                    _id: routeId
+                } = (isObject(route) ? route : tasks[route]) || {}
 
-        // })
+                const {
+                    _id: selectedRouteId
+                } = selectedTask || {}
+
+                if(routeId === selectedRouteId) return false    // selected route is shown separately, so don't double dip
+
+                const {
+                    position: loadPosition,
+                    station: loadStation
+                } = load || {}
+
+                const {
+                    position: unloadPosition,
+                    station: unloadStation
+                } = unload || {}
+
+                /*
+                * if we aren't editing a task, and it's missing load / unload don't show it.
+                * If we are a task, but its not this one, and this one is missine load / unload, don't show it
+                * */
+                if((!(editingTask) || (editingTask && selectedRouteId !== routeId)) && (!(loadPosition || loadStation) || !(unloadPosition || unloadStation))) return false
+                return true
+             })
+            .map((route, ind) => {
+                if( isObject(route) ) {
+                    return (
+                        <TaskPaths d3={d3} route={route} key={route._id} />
+                    )
+                }
+                else {
+                    return (
+                        <TaskPaths d3={d3} route={tasks[route]} key={route} />
+                    )
+                }
+            })
     }
 
     return (

--- a/src/containers/map_view/map_view.js
+++ b/src/containers/map_view/map_view.js
@@ -1,6 +1,6 @@
 import React, { Component, useState } from 'react'
 import { ReactDOM, Route } from 'react-dom'
-import { connect } from 'react-redux';
+import {connect, useSelector} from 'react-redux';
 import moduleName from 'react'
 import { withRouter } from "react-router-dom";
 
@@ -39,6 +39,7 @@ import log from "../../logger"
 import { setCurrentMap } from "../../redux/actions/map_actions";
 import { getPreviousRoute } from "../../methods/utils/processes_utils";
 import { isObject } from "../../methods/utils/object_utils";
+import {getHasStartAndEnd, getUnloadPositionId} from "../../methods/utils/route_utils";
 const logger = log.getLogger("MapView")
 
 export class MapView extends Component {
@@ -50,6 +51,7 @@ export class MapView extends Component {
 
         this.state = {
             showRightClickMenu: {},
+            hasStartAndEnd: false
         }
 
         this.rd3tSvgClassName = `__SVG`     // Gives uniqe className to map components to reference for d3 events
@@ -128,6 +130,9 @@ export class MapView extends Component {
         // }
         this.checkForMapLoad() //test
 
+        if(prevProps.selectedTask !== this.props.selectedTask) {
+            this.setState({hasStartAndEnd: getHasStartAndEnd(this.props.selectedTask)})
+        }
 
         // If the map has been changed, recalculate the geometry and bind the zoom
         // listener to default to the correct translation
@@ -566,8 +571,10 @@ export class MapView extends Component {
 
     render() {
         let { stations, positions, devices, selectedStation, selectedPosition, selectedStationChildrenCopy, deviceEnabled } = this.props
+        const { hasStartAndEnd } = this.state
         if (this.props.currentMap == null) { return (<></>) }
         const { translate, scale } = this.d3;
+
 
         return (
             <div style={{ width: '100%', height: '100%' }} onMouseMove={this.dragNewEntity} onMouseUp={this.validateNewLocation} >
@@ -652,7 +659,7 @@ export class MapView extends Component {
                             </foreignObject>
                         </styled.MapGroup>
 
-                        {!!this.props.selectedTask &&
+                        {!!this.props.selectedTask && (hasStartAndEnd || this.props.editingTask) &&
                             <TaskPaths d3={this.d3} />
                         }
 
@@ -813,6 +820,7 @@ const mapStateToProps = function (state) {
 
         selectedTask: state.tasksReducer.selectedTask,
         selectedHoveringTask: state.tasksReducer.selectedHoveringTask,
+        editingTask: state.tasksReducer.editingTask,
         selectedProcess: state.processesReducer.selectedProcess,
         fixingProcess: state.processesReducer.fixingProcess,
 

--- a/src/methods/utils/route_utils.js
+++ b/src/methods/utils/route_utils.js
@@ -108,6 +108,10 @@ export const getRouteEnd = (route) => {
     return hasEnd
 }
 
+export const getHasStartAndEnd = (route) => {
+    return getRouteEnd(route) && getRouteStart(route)
+}
+
 export const isStationLoadStation = (route, stationId) => {
     return stationId === getLoadStationId(route)
 }


### PR DESCRIPTION
Sometimes a station / position was incorrectly disabled / not disabled when editing a process.
This should fix it