### PR TITLE
Fix not being able to save process due to routes containing undefined obj: RM-98

### DIFF
--- a/src/methods/utils/route_utils.js
+++ b/src/methods/utils/route_utils.js
@@ -43,7 +43,7 @@ export const autoGenerateRoute = (obj) => {
                position: routeConfirmationLocation,
               },
         unload: {...defaultTask.unload},
-        obj: obj ? currentMap._id : currentMap._id,
+        obj: obj ? obj : null,
         _id: uuid.v4(), // NOTE - ID IS GENERATED HERE INSTEAD OF IN defaultTask SO THE ID IS GENERATED EACH TIME THE FUNCTION IS CALLED
     }
 }


### PR DESCRIPTION
Util for generating new tasks has obj key as undefined, which caused validation error