### PR TITLE
Fixes Bugs in Line Chart (See description)

### DIFF
--- a/src/components/widgets/widget_pages/statistics_page/statistics_overview/charts/throughput_chart/line_throughput_chart/line_throughput_chart.js
+++ b/src/components/widgets/widget_pages/statistics_page/statistics_overview/charts/throughput_chart/line_throughput_chart/line_throughput_chart.js
@@ -62,6 +62,11 @@ const LineThroughputChart = (props) => {
             }
         }
 
+        // If startIndex is undefined, then the start of the shift is after any data points
+        if(startIndex === undefined){
+            startIndex = dataCopy.length
+        }
+
         // Convert end of shift to epoch
         const endEpoch = convert24htoEpoch(shiftDetails.endOfShift, date)
         let endIndex = dataCopy.length

--- a/src/components/widgets/widget_pages/statistics_page/statistics_overview/statistics_overview.js
+++ b/src/components/widgets/widget_pages/statistics_page/statistics_overview/statistics_overview.js
@@ -107,7 +107,7 @@ const StatisticsOverview = (props) => {
     // On page load, load in the data for today
     useEffect(() => {
         getAllData()
-        const dataInterval = setInterval(() => getAllData(), 30000)
+        const dataInterval = setInterval(() => getAllData(), 3000)
         return () => {
             clearInterval(dataInterval)
         }
@@ -123,7 +123,6 @@ const StatisticsOverview = (props) => {
             setIsDevice(true)
         }
 
-        // TEMP
         // If the page has been loaded in (see widget pages) then don't delay chart load, 
         // else delay chart load because it slows down the widget page opening animation.
         if (widgetPageLoaded) {
@@ -134,11 +133,25 @@ const StatisticsOverview = (props) => {
             }, 300);
         }
 
-        // TEMP
         const body = { timespan: timeSpan, index: dateIndex }
         const dataPromise = getStationAnalytics(stationID, body)
         dataPromise.then(response => {
             if (response === undefined) return
+
+            // Convert Throughput for line chart
+            if (timeSpan === 'line') {
+                let convertedThroughput = []
+                response.throughPut.forEach((dataPoint) => {
+                    // Round Epoch time and multiply by 1000 to match front end times
+                    let convertedTime = dataPoint.x * 1000
+                    convertedTime = Math.round(convertedTime)
+                    convertedThroughput.push({ x: convertedTime, y: dataPoint.y })
+                })
+                response = {
+                    ...response,
+                    throughPut: convertedThroughput
+                }
+            }
             setThroughputData(response)
 
         })

--- a/src/components/widgets/widget_pages/statistics_page/statistics_overview/statistics_overview.js
+++ b/src/components/widgets/widget_pages/statistics_page/statistics_overview/statistics_overview.js
@@ -111,9 +111,7 @@ const StatisticsOverview = (props) => {
         return () => {
             clearInterval(dataInterval)
         }
-    }, [])
-
-
+    }, [timeSpan])
 
     const getAllData = () => {
         dispatchGetReportEvents() // load report events

--- a/src/components/widgets/widget_pages/statistics_page/statistics_overview/statistics_overview.js
+++ b/src/components/widgets/widget_pages/statistics_page/statistics_overview/statistics_overview.js
@@ -107,7 +107,7 @@ const StatisticsOverview = (props) => {
     // On page load, load in the data for today
     useEffect(() => {
         getAllData()
-        const dataInterval = setInterval(() => getAllData(), 3000)
+        const dataInterval = setInterval(() => getAllData(), 30000)
         return () => {
             clearInterval(dataInterval)
         }


### PR DESCRIPTION
Bug 1)

If data was before start of shift, the chart would still show the data before then
Test by changing shift times with data before and after shift points

Bug 2)
Refreshing line chat on station statistics broke after each resfresh
Test by letting page refresh for line chart