### PR TITLE
styling things

### DIFF
--- a/src/components/side_bar/content/settings/shift_settings/shift_settings.js
+++ b/src/components/side_bar/content/settings/shift_settings/shift_settings.js
@@ -183,7 +183,7 @@ const ShiftSettings = (props) => {
                                             }}
                                             name={breakStart}
                                             style={{ flex: '0 0 7rem', display: 'flex', flexWrap: 'wrap', textAlign: 'center', backgroundColor: '#6c6e78' }}
-                                            containerStyle={{ width: '5rem' }}
+                                            containerStyle={{ width: '6.5rem' }}
                                             showHour={true}
                                             showMinute={true}
                                             showSecond={false}
@@ -216,7 +216,7 @@ const ShiftSettings = (props) => {
                                             }}
                                             name={breakEnd}
                                             style={{ flex: '0 0 7rem', display: 'flex', flexWrap: 'wrap', textAlign: 'center', backgroundColor: '#6c6e78' }}
-                                            containerStyle={{ width: '6rem' }}
+                                            containerStyle={{ width: '6.5rem' }}
                                             showHour={true}
                                             showMinute={true}
                                             showSecond={false}

--- a/src/components/widgets/widget_button/widget_button.js
+++ b/src/components/widgets/widget_button/widget_button.js
@@ -200,19 +200,19 @@ const WidgetButton = (props) => {
                 :
                 type === 'cancel' ?
                     <>
-                        <styled.WidgetButtonIcon className="fas fa-times" pageID={type} currentPage={currentPage} />
-                        <styled.WidgetButtonText pageID={type} currentPage={currentPage}>{"Cancel"}</styled.WidgetButtonText>
+                    <styled.WidgetButtonIcon className="fas fa-times" pageID={type} currentPage={currentPage} active={type === currentPage} />
+                    <styled.WidgetButtonText pageID={type} currentPage={currentPage}>{"Cancel"} active={type === currentPage}</styled.WidgetButtonText>
                     </>
                     :
                     type === 'lots' ?
                         <>
-                            <styled.WidgetButtonIcon className="far fa-clone" pageID={type} currentPage={currentPage} />
-                            <styled.WidgetButtonText pageID={type} currentPage={currentPage}>{label}</styled.WidgetButtonText>
+                        <styled.WidgetButtonIcon className="far fa-clone" pageID={type} currentPage={currentPage} active={type === currentPage} />
+                        <styled.WidgetButtonText pageID={type} currentPage={currentPage} active={type === currentPage}>{label}</styled.WidgetButtonText>
                         </>
                         :
                         <>
-                            <styled.WidgetButtonIcon style={{ fontSize: type === 'cart' && '1.2rem', paddingTop: type === 'cart' && '.8rem' }} className={"icon-" + type} pageID={type} currentPage={currentPage} />
-                            <styled.WidgetButtonText pageID={type} currentPage={currentPage}>{label}</styled.WidgetButtonText>
+                        <styled.WidgetButtonIcon style={{ fontSize: type === 'cart' && '1.2rem', paddingTop: type === 'cart' && '.8rem' }} className={"icon-" + type} pageID={type} currentPage={currentPage} active={type === currentPage} />
+                        <styled.WidgetButtonText pageID={type} currentPage={currentPage} active={type === currentPage}>{label}</styled.WidgetButtonText>
                         </>
             }
             {/* <styled.ButtonText>{props.type}</styled.ButtonText> */}

--- a/src/components/widgets/widget_button/widget_button.style.js
+++ b/src/components/widgets/widget_button/widget_button.style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { stationColor } from '../../../constants/station_constants'
+import {LightenDarkenColor} from '../../../methods/utils/color_utils';
 
 export const WidgetButtonButton = styled.button`
 
@@ -24,9 +25,13 @@ export const WidgetButtonButton = styled.button`
         outline: 0 !important
     }
 
-    &:active{
+    &:active {
         box-shadow: none;
     }
+
+    &:hover{
+      background: ${props => !props.currentPage && LightenDarkenColor(props.theme.bg.primary, -10)};
+  }
 
     ${props => props.switcher &&
     `
@@ -35,20 +40,22 @@ export const WidgetButtonButton = styled.button`
         border-radius: 0.4rem;
         transform: none;
         margin: 0 0.2rem;
+        padding-top: .6rem;
     `
     }
 
     ${props => props.active &&
     `
-        background: ${props.theme.bg.tertiary};
+    background: ${props.theme.bg.primary};
     `
     }
 `;
 export const WidgetButtonText = styled.h4`
-    font-size: 0.6rem;
+    font-size: ${props => props.currentPage ? '.8rem': '0.6rem'};
     font-family: ${props => props.theme.font.primary};
+    padding-top: ${props=>props.currentPage && '0.2rem'};
 
-    color: ${stationColor};
+    color: ${props=>props.active || !props.currentPage ? stationColor : props.theme.bg.quaternary};
 
     @media (max-width: ${props => props.theme.widthBreakpoint.tablet}){
 
@@ -57,8 +64,8 @@ export const WidgetButtonText = styled.h4`
 
 
 export const WidgetButtonIcon = styled.i`
-    font-size: 1.8rem;
-    color: ${stationColor};
+    font-size: ${props => props.currentPage ? '2rem': '1.8rem'};
+    color: ${props=>props.active || !props.currentPage ? stationColor : props.theme.bg.quaternary};
 
     @media (max-width: ${props => props.theme.widthBreakpoint.tablet}){
         font-size: 2rem;


### PR DESCRIPTION
darken background when hovering over widget popup
button styling when pages are open (text/icon is larger, greyed out when not active)
error tooltip on shift settings overlap fix