### PR TITLE
Phone view

### DIFF
--- a/src/common_css/modal_css.js
+++ b/src/common_css/modal_css.js
@@ -12,8 +12,8 @@ export const ModalContainerCSS = styled(Modal)`
 	bottom: auto;
 	position: absolute;
 	z-index: 500;
-	
-	min-width: 30rem;
+
+	min-width: 15rem;
     max-width: 95%;
     width: ${isMobile && "95%"};
 

--- a/src/common_css/modal_css.js
+++ b/src/common_css/modal_css.js
@@ -13,6 +13,7 @@ export const ModalContainerCSS = styled(Modal)`
 	position: absolute;
 	z-index: 500;
 
+	width: 30rem;
 	min-width: 15rem;
     max-width: 95%;
     width: ${isMobile && "95%"};

--- a/src/components/basic/modals/simple_modal/simple_modal.js
+++ b/src/components/basic/modals/simple_modal/simple_modal.js
@@ -35,7 +35,7 @@ const SimpleModal = (props) => {
             style={{
                 overlay: {
                     zIndex: 500,
-                    backgroundColor: 'rgba(0, 0, 0, 0.4)' 
+                    backgroundColor: 'rgba(0, 0, 0, 0.4)'
                 },
                 content: {
 
@@ -63,7 +63,7 @@ const SimpleModal = (props) => {
                             {FooterContent}
                             <styled.ButtonContainers>
                                 <Button
-                                    style={{minWidth: '10rem'}}
+                                    style={{minWidth: '5rem'}}
                                     secondary
                                     onClick={handleOnClick1}
                                     label={button_1_text}
@@ -71,7 +71,7 @@ const SimpleModal = (props) => {
                                     disabled={button_1_disabled}
                                 />
                                 <Button
-                                    style={{minWidth: '10rem'}}
+                                    style={{minWidth: '5rem'}}
                                     onClick={handleOnClick2}
                                     label={button_2_text}
                                     type="button"

--- a/src/components/basic/modals/simple_modal/simple_modal.style.js
+++ b/src/components/basic/modals/simple_modal/simple_modal.style.js
@@ -83,7 +83,7 @@ export const Container = styled(Modal)`
 
 	z-index: 50;
 
-	min-width: 30rem;
+	min-width: 15rem;
   max-width: 95%;
   min-height: 20rem;
   max-height: 90%;
@@ -170,7 +170,7 @@ export const BodyContainer = styled.div`
 	justify-content: space-between;
 	overflow: hidden;
 
-  
+
 
 	background: ${props => props.theme.bg.primary};
 `

--- a/src/components/hil_modals/hil_modals.js
+++ b/src/components/hil_modals/hil_modals.js
@@ -22,6 +22,7 @@ import { isMobile } from "react-device-detect"
 
 // styles
 import * as styled from './hil_modals.style';
+import useWindowSize from '../../hooks/useWindowSize'
 
 // utils
 import { deepCopy } from '../../methods/utils/utils'
@@ -88,6 +89,9 @@ const HILModals = (props) => {
     const activeHilDashboards = useSelector(state => state.taskQueueReducer.activeHilDashboards)
     const dashboards = useSelector(state => state.dashboardsReducer.dashboards) || {}
     const stations = useSelector(state => state.stationsReducer.stations) || {}
+
+    const size = useWindowSize()
+    const phoneView = size.width < 500
 
     const [task, setTask] = useState(null)
     const {
@@ -246,7 +250,7 @@ const HILModals = (props) => {
         // This is used to make the tap of the HIL button respond quickly
         disptachHILResponse(hilLoadUnload === 'load' ? 'load' : 'unload')
         setTimeout(() => disptachHILResponse(''), 2000)
-        // If its a warehouse then go back 
+        // If its a warehouse then go back
         if (!!warehouse) {
             history.push(`/locations/${stationID}/dashboards/${dashboardID}`)
         }
@@ -351,7 +355,7 @@ const HILModals = (props) => {
                 style={{
                     display: "flex",
                     flexDirection: "column",
-                    alignItems: "center"
+                    alignItems: "center",
                 }}
             >
                 <styled.SubtitleContainer>
@@ -437,7 +441,7 @@ const HILModals = (props) => {
                                     overflow: "auto",
                                     paddingTop: "1rem",
                                     justifyContent: "space-between",
-                                    flex: 1
+                                    flex: 1,
                                 }}
                             >
                                 {!!lotId &&
@@ -447,28 +451,33 @@ const HILModals = (props) => {
                                             <styled.HilSubtitleMessage>Current Lot</styled.HilSubtitleMessage>
                                         </styled.SubtitleContainer>
 
-                                        <ScaleWrapper
-                                            scaleFactor={isMobile ? 0.75 : 1}
-                                        >
-                                            <LotContainer
-                                                showCustomFields={false}
-                                                lotId={lotId}
-                                                quantity={hilLoadUnload === 'unload' ? unloadQuantity : null}
-                                                binId={
-                                                    // If its a warehouse, the bin is going to be the previous station
-                                                    !!warehouse ?
-                                                        getPreviousWarehouseStation(processId, stationID)._id
-                                                        :
-                                                        hilLoadUnload === 'load' ?
-                                                            stationId || loadStationId
-                                                            :
-                                                            unloadStationId
+                                        {!phoneView ?
+                                          <ScaleWrapper
+                                              scaleFactor={isMobile ? 0.75 : 1}
+                                          >
+                                              <LotContainer
+                                                  showCustomFields={false}
+                                                  lotId={lotId}
+                                                  quantity={hilLoadUnload === 'unload' ? unloadQuantity : null}
+                                                  binId={
+                                                      // If its a warehouse, the bin is going to be the previous station
+                                                      !!warehouse ?
+                                                          getPreviousWarehouseStation(processId, stationID)._id
+                                                          :
+                                                          hilLoadUnload === 'load' ?
+                                                              stationId || loadStationId
+                                                              :
+                                                              unloadStationId
 
-                                                }
-                                                processId={processId}
-                                                containerStyle={{ margin: 0, padding: 0, width: "30rem" }}
-                                            />
-                                        </ScaleWrapper>
+                                                  }
+                                                  processId={processId}
+                                                  containerStyle={{ margin: 0, padding: 0, width: '100%' }}
+                                              />
+                                          </ScaleWrapper>
+                                          :
+                                          <styled.InfoText>{lot.name}</styled.InfoText>
+                                        }
+
                                     </styled.LotInfoContainer>
                                 }
 

--- a/src/components/list_view/list_view.js
+++ b/src/components/list_view/list_view.js
@@ -54,6 +54,7 @@ const ListView = (props) => {
     const dispatch = useDispatch()
     const history = useHistory()
     const params = useParams()
+
     const {
         dashboardID,
         editing,
@@ -61,11 +62,11 @@ const ListView = (props) => {
         stationID,
         warehouse
     } = params
-    console.log('hey')
 
     const size = useWindowSize()
     const windowWidth = size.width
     const widthBreakPoint = 1025
+    const phoneView = windowWidth < 500
 
     const positions = useSelector(state => state.positionsReducer.positions)
     const stations = useSelector(state => state.stationsReducer.stations)
@@ -349,7 +350,7 @@ const ListView = (props) => {
                             }
 
 
-                    <styled.Title schema={CURRENT_SCREEN.schema} style={{ userSelect: "none" }}>{title}</styled.Title>
+                    <styled.Title schema={CURRENT_SCREEN.schema} style={{ userSelect: "none" }} phoneView = {phoneView}>{title}</styled.Title>
                     {handleTaskQueueStatus()}
 
                     {!!deviceEnabled &&

--- a/src/components/list_view/list_view.js
+++ b/src/components/list_view/list_view.js
@@ -13,7 +13,6 @@ import ConfirmDeleteModal from '../basic/modals/confirm_delete_modal/confirm_del
 import ScanLotModal from '../../components/basic/modals/scan_lot_modal/scan_lot_modal'
 import { ADD_TASK_ALERT_TYPE } from "../../constants/dashboard_constants";
 import TaskAddedAlert from "../../components/widgets/widget_pages/dashboards_page/dashboard_screen/task_added_alert/task_added_alert";
-
 // Import hooks
 import useWindowSize from '../../hooks/useWindowSize'
 
@@ -62,6 +61,7 @@ const ListView = (props) => {
         stationID,
         warehouse
     } = params
+    console.log('hey')
 
     const size = useWindowSize()
     const windowWidth = size.width

--- a/src/components/list_view/list_view.style.js
+++ b/src/components/list_view/list_view.style.js
@@ -39,7 +39,7 @@ export const Title = styled.span`
     transform: translateX(-50%);
 
     font-family: ${props => props.theme.font.primary};
-    font-size: ${props => props.theme.fontSize.sz1};
+    font-size: ${props => props.phoneView ?  props.theme.fontSize.sz2 : props.theme.fontSize.sz1};
     font-weight: 500;
     color: ${props => props.theme.schema[props.schema].solid};
 `

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_buttons/dashboard_button/dashboard_button.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_buttons/dashboard_button/dashboard_button.js
@@ -68,7 +68,7 @@ const DashboardButton = (props => {
                         <path d="M300,8v51c0,4.4-3.6,8-8,8H8.8L63.5,0H292C296.4,0,300,3.6,300,8z" />
                     </svg>
                     <style.IconContainer>
-                        <style.SchemaIcon className={iconClassName} color={color ? color : iconColor}/>
+                        <style.SchemaIcon style = {{position: 'absolute', left: '6rem'}} className={iconClassName} color={color ? color : iconColor}/>
                     </style.IconContainer>
                 </>
             }

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_operations_menu/dashboard_operations_menu.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_operations_menu/dashboard_operations_menu.js
@@ -216,4 +216,3 @@ const DashboardOperationsMenu = (props) => {
 }
 
 export default DashboardOperationsMenu
-

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/dashboard_lot_list/dashboard_lot_list.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/dashboard_lot_list/dashboard_lot_list.js
@@ -12,6 +12,7 @@ import SortFilterContainer from '../../../../../side_bar/content/cards/sort_filt
 // Import Utils
 import { getIsCardAtBin, getMatchesFilter } from '../../../../../../methods/utils/lot_utils'
 import { sortBy } from '../../../../../../methods/utils/card_utils'
+import useWindowSize from '../../../../../../hooks/useWindowSize'
 
 // Import Constants
 import { LOT_FILTER_OPTIONS, SORT_DIRECTIONS } from '../../../../../../constants/lot_contants'
@@ -40,6 +41,9 @@ const DashboardLotList = () => {
     const [sortDirection, setSortDirection] = useState(SORT_DIRECTIONS.ASCENDING)
     const [shouldFocusLotFilter, setShouldFocusLotFilter] = useState(false)
     const [selectedFilterOption, setSelectedFilterOption] = useState(LOT_FILTER_OPTIONS.name)
+
+    const size = useWindowSize()
+    const phoneView = size.width < 500
 
     const station = stations[stationID]
 
@@ -73,9 +77,9 @@ const DashboardLotList = () => {
             const quantityAtStation = lot.bins[stationID].count
             const lotHasQuantityAlreadyAtStation = currTaskQueue?.quantity !== quantityAtStation
 
-            // If lot is in the task, 
+            // If lot is in the task,
             // lot does not have quantity at the station
-            // the device is driving to the next position or the device is at unload, 
+            // the device is driving to the next position or the device is at unload,
             // then dont show card on dashboard
             if (currLotIsInTaskQ && !lotHasQuantityAlreadyAtStation && (!!currTaskQueue?.next_position || deviceAtUnload)) {
                 return false
@@ -136,18 +140,20 @@ const DashboardLotList = () => {
 
     return (
         <styled.LotListContainer>
-            <SortFilterContainer
-                lotFilterValue={lotFilterValue}
-                sortMode={sortMode}
-                setSortMode={setSortMode}
-                sortDirection={sortDirection}
-                setSortDirection={setSortDirection}
-                shouldFocusLotFilter={shouldFocusLotFilter}
-                setLotFilterValue={setLotFilterValue}
-                selectedFilterOption={selectedFilterOption}
-                setSelectedFilterOption={setSelectedFilterOption}
-                containerStyle={{ justifyContent: 'center' }}
-            />
+            {!phoneView &&
+              <SortFilterContainer
+                  lotFilterValue={lotFilterValue}
+                  sortMode={sortMode}
+                  setSortMode={setSortMode}
+                  sortDirection={sortDirection}
+                  setSortDirection={setSortDirection}
+                  shouldFocusLotFilter={shouldFocusLotFilter}
+                  setLotFilterValue={setLotFilterValue}
+                  selectedFilterOption={selectedFilterOption}
+                  setSelectedFilterOption={setSelectedFilterOption}
+                  containerStyle={{ justifyContent: 'center' }}
+              />
+            }
             <styled.LotCardContainer>
                 {renderLotCards}
             </styled.LotCardContainer>

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/dashboard_lot_list/dashboard_lot_list.style.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/dashboard_lot_list/dashboard_lot_list.style.js
@@ -16,4 +16,5 @@ export const LotCardContainer = styled.div`
     flex-wrap: wrap;
     justify-content: center;
     width: 100%;
+    overflow: auto;
 `

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/dashboard_lot_page/dashboard_lot_page.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/dashboard_lot_page/dashboard_lot_page.js
@@ -106,7 +106,7 @@ const DashboardLotPage = (props) => {
                 setCurrentTask(returnedRoute)
             }
 
-            // go back if lot has no items at this station (ex. just moved them all). 
+            // go back if lot has no items at this station (ex. just moved them all).
             // Dont go back though if the prevStation was a warehouse
             // Doesn't make sense to stay on this screen
             if (isObject(lot) && isObject(lot?.bins)) {

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/dashboard_lot_page/dashboard_lot_page.style.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/dashboard_lot_page/dashboard_lot_page.style.js
@@ -16,21 +16,23 @@ export const LotHeader = styled.div`
     ${commonCss.rowContainer}
     align-items: center;
     text-align: center;
-    justify-content: center;    
+    justify-content: center;
     height: fit-content;
 `
 
-export const LotTitle = styled.p`
+export const LotTitle = styled.h1`
     color: ${props => props.theme.bg.octonary};
     font-family: ${props => props.theme.font.primary};
-    font-size: ${props => props.theme.fontSize.sz1};
-
+    font-size: 1.8rem;
+    max-height: 2.5rem;
+    flex-wrap: nowrap;
+    overflow: hidden;
     /* margin-bottom: 0;
     position: absolute;
     text-align: center;
-    left: 0; 
-    right: 0; 
-    margin-left: auto; 
+    left: 0;
+    right: 0;
+    margin-left: auto;
     margin-right: auto;  */
 
 `
@@ -62,7 +64,6 @@ export const LotBodyContainer = styled.div`
     flex-direction: column;
     /* flex: 6; */
     flex-grow: 1;
-    padding: 0rem 1rem;
+    padding: 0.5rem 1rem;
     z-index: 1;
 `
-

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/kick_off_modal/kick_off_modal.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/kick_off_modal/kick_off_modal.js
@@ -32,6 +32,7 @@ import LotFilterBar from "../../../../../side_bar/content/cards/lot_filter_bar/l
 import {getLotTemplates} from "../../../../../../redux/actions/lot_template_actions";
 import LotEditorContainer from "../../../../../side_bar/content/cards/card_editor/lot_editor_container";
 import SortFilterContainer from "../../../../../side_bar/content/cards/sort_filter_container/sort_filter_container";
+import useWindowSize from '../../../../../../hooks/useWindowSize'
 
 Modal.setAppElement('body');
 
@@ -78,6 +79,10 @@ const KickOffModal = (props) => {
 
     const isButtons = availableKickOffCards.length > 0
     const stationId = dashboard.station
+
+    const size = useWindowSize()
+    const windowWidth = size.width
+    const phoneView = windowWidth < 500
 
     const onButtonClick = async (lot) => {
         setShowQuantitySelector(true)
@@ -373,7 +378,7 @@ const KickOffModal = (props) => {
             style={{
                 overlay: {
                     zIndex: 500,
-                    backgroundColor: 'rgba(0, 0, 0, 0.4)' 
+                    backgroundColor: 'rgba(0, 0, 0, 0.4)'
                 },
             }}
         >
@@ -398,17 +403,20 @@ const KickOffModal = (props) => {
                     <styled.CloseIcon className="fa fa-times" aria-hidden="true" onClick={close}/>
 
                 </styled.HeaderMainContentContainer>
-                <SortFilterContainer
-                    lotFilterValue={lotFilterValue}
-                    sortMode={sortMode}
-                    setSortMode={setSortMode}
-                    sortDirection={sortDirection}
-                    setSortDirection={setSortDirection}
-                    shouldFocusLotFilter={shouldFocusLotFilter}
-                    setLotFilterValue={setLotFilterValue}
-                    selectedFilterOption={selectedFilterOption}
-                    setSelectedFilterOption={setSelectedFilterOption}
-                />
+                {!phoneView &&
+                  <SortFilterContainer
+                      lotFilterValue={lotFilterValue}
+                      sortMode={sortMode}
+                      setSortMode={setSortMode}
+                      sortDirection={sortDirection}
+                      setSortDirection={setSortDirection}
+                      shouldFocusLotFilter={shouldFocusLotFilter}
+                      setLotFilterValue={setLotFilterValue}
+                      selectedFilterOption={selectedFilterOption}
+                      setSelectedFilterOption={setSelectedFilterOption}
+                  />
+                }
+
 
 
             </styled.Header>
@@ -442,16 +450,19 @@ const KickOffModal = (props) => {
                                 label={"Close"}
                                 type="button"
                             /> */}
-                            <Button
-                                // tertiary
-                                // secondary
-                                schema={"dashboards"}
-                                // onClick={close}
-                                onClick={()=>setShowLotEditor(true)}
-                                label={"Create New Lot"}
-                                type="button"
-                                style={{minWidth: '12rem', minHeight: '3rem'}}
-                            />
+                            {!phoneView &&
+                              <Button
+                                  // tertiary
+                                  // secondary
+                                  schema={"dashboards"}
+                                  // onClick={close}
+                                  onClick={()=>setShowLotEditor(true)}
+                                  label={"Create New Lot"}
+                                  type="button"
+                                  style={{minWidth: '12rem', minHeight: '3rem'}}
+                              />
+                            }
+
                         </styled.ButtonsContainer>
                     </div>
             </styled.BodyContainer>

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/report_modal/report_button/report_button.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/report_modal/report_button/report_button.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types'
 
 // styles
 import * as styled from "./report_button.style"
+import useWindowSize from '../../../../../../../hooks/useWindowSize'
 
 const ReportButton = (props) => {
 
@@ -21,6 +22,9 @@ const ReportButton = (props) => {
 		invert,
 		editing
 	} = props
+
+	const size = useWindowSize()
+	const phoneView = size.width < 500
 
 	return (
 		<styled.ButtonWidthContainer key={id} className={className}
@@ -38,8 +42,8 @@ const ReportButton = (props) => {
 				iconColor={color}
 
 				containerStyle={{
-					height: '4rem',
-					minHeight: "4rem",
+					height: phoneView ? '2rem' : '4rem',
+					minHeight: phoneView ? '2rem' : '4rem',
 					margin: '0.5rem auto',
 					flex: 1,
 					width: "unset",

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/report_modal/report_modal.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/report_modal/report_modal.js
@@ -286,7 +286,7 @@ const ReportModal = (props) => {
                             />
 
                             {
-                                checkPermission(null, EDIT_REPORT_BUTTONS_REQUEST) &&
+                                checkPermission(null, EDIT_REPORT_BUTTONS_REQUEST) && !phoneView &&
                                 <Button
                                     primary
                                     schema={"dashboards"}

--- a/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/report_modal/report_modal.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboard_screen/report_modal/report_modal.js
@@ -30,6 +30,7 @@ import {
 import ReportButton from "./report_button/report_button";
 import {ThemeContext} from "styled-components";
 import ScrollContainer from "../../../../../basic/scroll_container/scroll_container";
+import useWindowSize from '../../../../../../hooks/useWindowSize'
 
 Modal.setAppElement('body');
 
@@ -58,6 +59,10 @@ const ReportModal = (props) => {
     const [submitting, setSubmitting] = useState(false)
     const [dragging, setDragging] = useState(null)
 
+    const size = useWindowSize()
+    const windowWidth = size.width
+    const phoneView = windowWidth < 500
+
     const formRef = useRef(null)	// gets access to form state
     const {
         current
@@ -75,6 +80,8 @@ const ReportModal = (props) => {
         setFieldValue = () => { },
         setStatus = () => { },
     } = current || {}
+
+
 
     useEffect(() => {
         setNoButtons(!isNonEmptyArray(dashboard?.report_buttons))
@@ -191,6 +198,7 @@ const ReportModal = (props) => {
                 </Button>
             </styled.Header>
 
+
             <styled.BodyContainer>
                 {(addingNew || sending) ?
                     <NewButtonForm
@@ -206,6 +214,7 @@ const ReportModal = (props) => {
                     :
                     <div style={{ display: "flex", flexDirection: "column", overflow: "hidden" }}>
                         <styled.ContentContainer>
+                          {!phoneView &&
                             <styled.AddNewButtonContainer
                                 showBorder={!noButtons}
                             >
@@ -219,7 +228,7 @@ const ReportModal = (props) => {
                                 />
 
                             </styled.AddNewButtonContainer>
-
+                          }
                             {!noButtons &&
                                     <ScrollContainer>
                                     {editing ?

--- a/src/components/widgets/widget_pages/dashboards_page/dashboards_header/dashboards_header.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboards_header/dashboards_header.js
@@ -24,6 +24,7 @@ import { getBinQuantity, getIsCardAtBin } from "../../../../../methods/utils/lot
 import * as styled from './dashboards_header.style';
 
 const widthBreakPoint = 1000;
+const phoneViewBreakPoint = 500;
 
 const DashboardsHeader = (props) => {
 
@@ -49,7 +50,8 @@ const DashboardsHeader = (props) => {
     const size = useWindowSize()
     const windowWidth = size.width
     const mobileMode = windowWidth < widthBreakPoint;
-
+    const phoneView = windowWidth < phoneViewBreakPoint;
+    
     const name = currentDashboard.name.length > 0 ? currentDashboard.name : stations[currentDashboard.station].name
 
     useEffect(() => {
@@ -68,38 +70,75 @@ const DashboardsHeader = (props) => {
                         onClick={onBack}
                     />
                 }*/}
+                {!phoneView ?
+                  <>
+                    <Button
+                        schema="dashboards"
+                        onClick={() => {
+                            setShowOperationsMenu(true)
+                        }}
+                        disabled={showOperationsMenu}
+                        style={{ height: '3rem', boxShadow: '0px 1px 3px 1px rgba(0,0,0,0.2)' }}
+                    >
+                        Operations
+                    </Button>
+                    <Button
+                        schema="delete"
+                        onClick={() => {
+                            handleOperationSelected('report')
+                            setShowOperationsMenu(false)
+                        }}
+                        disabled={showOperationsMenu}
+                        style={{
+                            height: '3rem',
+                            boxShadow: '0px 1px 3px 1px rgba(0,0,0,0.2)' ,
+                            display: 'flex',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                            position: 'absolute',
+                            right: '1rem'
 
-                <Button
-                    schema="dashboards"
-                    onClick={() => {
-                        setShowOperationsMenu(true)
-                    }}
-                    disabled={showOperationsMenu}
-                    style={{ height: '3rem', boxShadow: '0px 1px 3px 1px rgba(0,0,0,0.2)' }}
-                >
-                    Operations
-                </Button>
-                <Button
-                    schema="delete"
-                    onClick={() => {
-                        handleOperationSelected('report')
-                        setShowOperationsMenu(false)
-                    }}
-                    disabled={showOperationsMenu}
-                    style={{ 
-                        height: '3rem', 
-                        boxShadow: '0px 1px 3px 1px rgba(0,0,0,0.2)' ,
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        position: 'absolute',
-                        right: '1rem'
-                        
-                    }}
-                >
-                    Report
-                    {/* <styled.ReportIcon className={'fas fa-exclamation-triangle'} /> */}
-                </Button>
+                        }}
+                    >
+                        Report
+                        {/* <styled.ReportIcon className={'fas fa-exclamation-triangle'} /> */}
+                    </Button>
+                  </>
+                  :
+                  <>
+                    <Button
+                        schema="dashboards"
+                        onClick={() => {
+                            setShowOperationsMenu(true)
+                        }}
+                        disabled={showOperationsMenu}
+                        style={{ height: '3rem', boxShadow: '0px 1px 3px 1px rgba(0,0,0,0.2)' }}
+                    >
+                      <i class="fas fa-list" style = {{color: '#FFFFFF'}}></i>
+                    </Button>
+                    <Button
+                        schema="delete"
+                        onClick={() => {
+                            handleOperationSelected('report')
+                            setShowOperationsMenu(false)
+                        }}
+                        disabled={showOperationsMenu}
+                        style={{
+                            height: '3rem',
+                            boxShadow: '0px 1px 3px 1px rgba(0,0,0,0.2)' ,
+                            display: 'flex',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                            position: 'absolute',
+                            right: '1rem'
+
+                        }}
+                    >
+                      <i class="fas fa-exclamation" style = {{color: '#FFFFFF'}}></i>
+                    </Button>
+                  </>
+                }
+
 
                 <styled.Title>{name}</styled.Title>
                 {/* <styled.PaceContainer

--- a/src/components/widgets/widget_pages/dashboards_page/dashboards_header/dashboards_header.style.js
+++ b/src/components/widgets/widget_pages/dashboards_page/dashboards_header/dashboards_header.style.js
@@ -32,8 +32,6 @@ export const Title = styled.h2`
     font-family: ${props => props.theme.font.primary};
     font-size: ${props => props.theme.fontSize.sz1};
 
-
-
     user-select: none;
 
 
@@ -52,6 +50,12 @@ export const Title = styled.h2`
     @media only screen and (max-width: ${props => props.theme.widthBreakpoint.tablet}) {
         font-size: ${props => props.theme.fontSize.sz2};
         max-width: 15rem;
+        text-overflow: ellipsis;
+    }
+
+    @media only screen and (max-width: ${props => props.theme.widthBreakpoint.mobileL}) {
+        font-size: ${props => props.theme.fontSize.sz2};
+        max-width: 10rem;
         text-overflow: ellipsis;
     }
 
@@ -111,6 +115,11 @@ export const LockIcon = styled.i`
     margin-top: 0rem;
     margin-left: 1rem;
 `
+export const Icon = styled.i`
+    font-size: 1.3rem;
+    color: blue;
+`
+
 
 export const SidebarButton = styled(AssignmentOutlinedIcon)`
     font-family: ${props => props.theme.font.primary};


### PR DESCRIPTION
-dont show filtering on phone view. Its a pain to format when screen is small
-report buttons only icon
-dashboard name smaller width to prevent overflow
-Dashboard title smaller on phone screen
-Task Q modal make min width so it fits small screen
-report button text name overflow
-disable add report in phoneview
-disable make new lot in kickoff modal
-min width made smaller in kicking off existing lot modal
-dont show whole lot card in move modal in phone view
