### PR TITLE
Reverting master to avoid dev bug + location editing 

### DIFF
--- a/src/components/side_bar/content/locations/edit_location/edit_location.js
+++ b/src/components/side_bar/content/locations/edit_location/edit_location.js
@@ -477,6 +477,7 @@ const EditLocation = (props) => {
                                         changed={() => handlePageDataChange()}
                                         textStyle={{ fontWeight: 'Bold', 'fontSize': '3rem' }}
                                         placeholder='Enter Location Name'
+                                        focus={!values.locationName}
                                         type='text'
                                         label='Location Name'
                                         schema='locations'


### PR DESCRIPTION
-Reset master back 2 commits got rid of bug that was introduced by merging development stuff by accident. The bug was creating a new lot to kickoff would freeze page (no idea what was causing it)

-When editing new location the cursor starts in the textbox instead of having to click into it